### PR TITLE
When coding in Dutch, ij should not look like a single narrow letter.

### DIFF
--- a/sources/GoogleSansCode-Italic.glyphspackage/fontinfo.plist
+++ b/sources/GoogleSansCode-Italic.glyphspackage/fontinfo.plist
@@ -803,7 +803,6 @@ featurePrefixes = (
 code = "languagesystem DFLT dflt;
 languagesystem latn dflt;
 
-languagesystem latn NLD;
 languagesystem latn ROM;
 languagesystem latn LSM;
 languagesystem latn ISM;
@@ -991,19 +990,26 @@ lookup ccmp_latn_catalanRecompose {
 	sub L' periodcentered' [L l] by Ldot;
 	sub l' periodcentered' l by ldot;
 } ccmp_latn_catalanRecompose;
+
+# Use ijacute.
+lookup ccmp_latn_ijacute {
+    sub ij acutecomb by ijacute;
+    sub IJ acutecomb by IJacute;
+} ccmp_latn_ijacute;
 ";
 tag = ccmp;
 },
 {
 code = "script latn;
 
-language NLD;
-lookup locl_latn_NLD_IJ{
-	sub i j by ij;
-	sub I J by IJ;
-	sub iacute j by ijacute;
-	sub Iacute J by IJacute;
-}locl_latn_NLD_IJ;
+# This is an anti-pattern. When coding in Dutch, ij should not look like a single narrow letter.
+# language NLD;
+# lookup locl_latn_NLD_IJ{
+# 	sub i j by ij;
+# 	sub I J by IJ;
+# 	sub iacute j by ijacute;
+# 	sub Iacute J by IJacute;
+# }locl_latn_NLD_IJ;
 
 language ROM;
 lookup locl_latn_ROM_MOL_commaaccent {

--- a/sources/GoogleSansCode-Italic.glyphspackage/fontinfo.plist
+++ b/sources/GoogleSansCode-Italic.glyphspackage/fontinfo.plist
@@ -1002,15 +1002,6 @@ tag = ccmp;
 {
 code = "script latn;
 
-# This is an anti-pattern. When coding in Dutch, ij should not look like a single narrow letter.
-# language NLD;
-# lookup locl_latn_NLD_IJ{
-# 	sub i j by ij;
-# 	sub I J by IJ;
-# 	sub iacute j by ijacute;
-# 	sub Iacute J by IJacute;
-# }locl_latn_NLD_IJ;
-
 language ROM;
 lookup locl_latn_ROM_MOL_commaaccent {
 	sub Scedilla by Scommaaccent;

--- a/sources/GoogleSansCode.glyphspackage/fontinfo.plist
+++ b/sources/GoogleSansCode.glyphspackage/fontinfo.plist
@@ -803,7 +803,6 @@ featurePrefixes = (
 code = "languagesystem DFLT dflt;
 languagesystem latn dflt;
 
-languagesystem latn NLD;
 languagesystem latn ROM;
 languagesystem latn LSM;
 languagesystem latn ISM;
@@ -991,19 +990,26 @@ lookup ccmp_latn_catalanRecompose {
 	sub L' periodcentered' [L l] by Ldot;
 	sub l' periodcentered' l by ldot;
 } ccmp_latn_catalanRecompose;
+
+# Use ijacute.
+lookup ccmp_latn_ijacute {
+    sub ij acutecomb by ijacute;
+    sub IJ acutecomb by IJacute;
+} ccmp_latn_ijacute;
 ";
 tag = ccmp;
 },
 {
 code = "script latn;
 
-language NLD;
-lookup locl_latn_NLD_IJ {
-	sub i j by ij;
-	sub I J by IJ;
-	sub iacute j by ijacute;
-	sub Iacute J by IJacute;
-} locl_latn_NLD_IJ;
+# This is an anti-pattern. When coding in Dutch, ij should not look like a single narrow letter.
+# language NLD;
+# lookup locl_latn_NLD_IJ {
+# 	sub i j by ij;
+# 	sub I J by IJ;
+# 	sub iacute j by ijacute;
+# 	sub Iacute J by IJacute;
+# } locl_latn_NLD_IJ;
 
 language ROM;
 lookup locl_latn_ROM_commaaccent {

--- a/sources/GoogleSansCode.glyphspackage/fontinfo.plist
+++ b/sources/GoogleSansCode.glyphspackage/fontinfo.plist
@@ -1002,15 +1002,6 @@ tag = ccmp;
 {
 code = "script latn;
 
-# This is an anti-pattern. When coding in Dutch, ij should not look like a single narrow letter.
-# language NLD;
-# lookup locl_latn_NLD_IJ {
-# 	sub i j by ij;
-# 	sub I J by IJ;
-# 	sub iacute j by ijacute;
-# 	sub Iacute J by IJacute;
-# } locl_latn_NLD_IJ;
-
 language ROM;
 lookup locl_latn_ROM_commaaccent {
 	sub Scedilla by Scommaaccent;


### PR DESCRIPTION
The current feature code `sub i j by ij` and `sub iacute j by ijacute;`, and the equivalent substitutions for capitals in the locl NLD for Dutch are an [anti-pattern](https://en.wikipedia.org/wiki/Anti-pattern), especially in coding context.

The current Google Sans Code shows ij in an unexpected manner in monospace context when applications are showing code in Dutch:
<img width="186" height="21" alt="Screenshot 2025-08-20 at 15 06 47" src="https://github.com/user-attachments/assets/05eaf21b-293c-4b6c-aa5d-e9e470676ce5" />

In comparison Noto Sans Mono shows ij as expected:
<img width="186" height="21" alt="Screenshot 2025-08-20 at 15 05 49" src="https://github.com/user-attachments/assets/cc446d84-008d-40d2-b05e-5ca6c6f74fae" />

This patch disables the locl NLD feature and replaces the `sub iacute j by ijacute;` in locl NLD by `sub ij acutecomb by ijacute;` in ccmp default.

For example:
<img width="186" height="21" alt="Screenshot 2025-08-20 at 15 05 18" src="https://github.com/user-attachments/assets/b21436d3-5b8a-4238-9312-312118dd2af9" />

Doing such a substitution is an anti-pattern, it is counterproductive and break things rather than solve the problem it is trying to solve. The Taalunie, the standard body in charge of the Dutch language, considers ij to be a digraph i+j that behaves like a letter in some contexts, for example in crosswords (ij in one cell) or when capitalized at the beginning of words (IJzer). There are also cases where ij is purely a digraph, for example in foreign or borrowed words. There is no reason it should be a narrow letter by default, in particular when the characters Ĳ and ĳ are available for that purpose.

The acute on the j is usually omitted, as described in the official spelling rules, it shouldn’t be added by the font if it’s not in the character string. The standard way to have the j with acute is to use the combining acute with j. The current feature code breaks both:
<img width="82" height="50" alt="Screenshot 2025-08-20 at 15 22 47" src="https://github.com/user-attachments/assets/411a9fc1-1243-4d48-855d-bc16e124c6ba" />
