### PR TITLE
Upgrade fontc

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install cargo-binstall
       uses: cargo-bins/cargo-binstall@v1.14.1
     - name: Use cargo-binstall to grab precompiled fontc
-      run: cargo binstall fontc@0.2.0
+      run: cargo binstall fontc@0.3.1
     - name: Build upright font
       run: fontc sources/GoogleSansCode.glyphspackage --flatten-components --decompose-transformed-components --output-file fonts/variable/GoogleSansCode[wght].ttf
     - name: Build italic font

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -100,7 +100,7 @@ filelock==3.17.0
     # via youseedee
 font-v==2.1.0
     # via gftools
-fontbakery[beautifulsoup4,googlefonts,googlefontsalwayslatest,shaperglot]==1.0.0
+fontbakery[beautifulsoup4,googlefonts,googlefontsalwayslatest,shaperglot]==1.0.1
     # via
     #   -r requirements-test.in
     #   gftools


### PR DESCRIPTION
This should fix https://github.com/googlefonts/googlesans-code/issues/22.

Also upgrades fontbakery to v1.0.1 from v1.0.0 to make the version check pass.

See https://github.com/googlefonts/fontations/pull/1601 for the cause of the issue.